### PR TITLE
fix(gitops-system): prune invalid tuppr drain block, info log level, enable monitoring

### DIFF
--- a/kubernetes/apps/gitops-system/system-upgrade-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/gitops-system/system-upgrade-controller/app/helmrelease.yaml
@@ -13,3 +13,8 @@ spec:
   values:
     fullnameOverride: *name
     replicaCount: 2
+    controller:
+      logLevel: info
+    monitoring:
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/apps/gitops-system/system-upgrade-controller/plans/talos.yaml
+++ b/kubernetes/apps/gitops-system/system-upgrade-controller/plans/talos.yaml
@@ -16,10 +16,6 @@ spec:
       - start: "0 1 * * 0"
         duration: "4h"
         timezone: "Asia/Shanghai"
-  drain:
-    deleteLocalData: true
-    ignoreDaemonSets: true
-    force: true
   parallelism: 1
   policy:
     force: false


### PR DESCRIPTION
## Fixes from the 2026-08-02 gitops-system review

- **M3** — `kubernetes/apps/gitops-system/system-upgrade-controller/plans/talos.yaml`: deleted the entire `drain:` block. Keys `deleteLocalData`/`ignoreDaemonSets`/`force` are rancher/system-upgrade-controller schema and are silently pruned by tuppr's CRD validation; tuppr's own drain field is deprecated. Default drain behavior is unchanged. Evidence: https://github.com/home-operations/tuppr/blob/0.4.6/charts/tuppr/crds/tuppr.home-operations.com_talosupgrades.yaml
- **GT-3** — `kubernetes/apps/gitops-system/system-upgrade-controller/app/helmrelease.yaml`: set `controller.logLevel: info` (chart default is `debug`) and enabled `monitoring.serviceMonitor.enabled: true`. Key shapes verified against the pinned chart values: https://github.com/home-operations/tuppr/blob/0.4.6/charts/tuppr/values.yaml (`controller.logLevel`, `monitoring.serviceMonitor.enabled`). The cluster's VictoriaMetrics operator converts ServiceMonitor CRDs (`enable_converter_ownership: true` in `monitoring-system/victoria-metrics/operator/helmrelease.yaml`), so no VMServiceScrape is needed. `prometheusRule` and `dashboards` intentionally left disabled.

The flux-instance `artifact: ""` workaround is intentionally untouched.

---
Review date 2026-08-02. No cluster changes take effect until Flux reconciles post-merge.
