### PR TITLE
fix(kube-system): k8tz 0.20.0 security bump, dead values cleanup, trim frr-k8s advertised prefixes

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -73,7 +73,7 @@ spec:
     ipv4NativeRoutingCIDR: 10.100.0.0/17
     k8sServiceHost: localhost
     k8sServicePort: 7445
-    kubeProxyReplacement: true
+    kubeProxyReplacement: "true"
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     l2announcements:
       enabled: false

--- a/kubernetes/apps/kube-system/frr-k8s/cluster/frrconfiguration.yaml
+++ b/kubernetes/apps/kube-system/frr-k8s/cluster/frrconfiguration.yaml
@@ -22,7 +22,6 @@ spec:
               allowed:
                 mode: all
         prefixes:
-          - "10.100.0.0/17" # Pod
           - "10.10.0.128/27" # LoadBalancer
     bfdProfiles:
       - name: default

--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -16,6 +16,7 @@ spec:
     serviceMonitor:
       enabled: true
     args:
+      # Accepted risk: required because Talos serves kubelet API with self-signed certs.
       - --kubelet-insecure-tls
       - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
       - --kubelet-use-node-status-port

--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -12,7 +12,6 @@ spec:
 
   values:
     spegel:
-      appendMirrors: true
       containerdSock: /run/containerd/containerd.sock
       containerdRegistryConfigPath: /etc/cri/conf.d/hosts
     service:


### PR DESCRIPTION
Applies kube-system review findings (review date 2026-08-02). No cluster changes until Flux reconciles post-merge.

- **M7 — k8tz** (`kubernetes/apps/kube-system/k8tz/app/ocirepository.yaml`): chart tag `0.19.0` → `0.20.0`. Security-flagged release (2026-07-18), no breaking changes. Evidence: https://artifacthub.io/packages/helm/k8tz/k8tz
- **spegel** (`kubernetes/apps/kube-system/spegel/app/helmrelease.yaml`): deleted dead key `spegel.appendMirrors` — removed in chart 0.1.0; mirror add is default via `containerdMirrorAdd: true`. Verified key absent from upstream pinned values: https://raw.githubusercontent.com/spegel-org/spegel/v0.7.4/charts/spegel/values.yaml
- **cilium** (`kubernetes/apps/kube-system/cilium/app/helmrelease.yaml`): `kubeProxyReplacement: true` → `kubeProxyReplacement: "true"` (quoted form per upstream docs examples; boolean still accepted, hygiene only). Evidence: https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/values.yaml
- **metrics-server** (`kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml`): added comment above `--kubelet-insecure-tls` documenting the accepted risk — required for Talos self-signed kubelet serving certs.
- **frr-k8s** (`kubernetes/apps/kube-system/frr-k8s/cluster/frrconfiguration.yaml`): removed the `10.100.0.0/17 # Pod` prefix advertisement (kept the LB `10.10.0.128/27`). Intranet users only need LB-IP reachability (external-dns → AdGuard → LB IP); pod-CIDR routes on the switch are surplus — cross-node pod routing is handled on-node by Cilium `autoDirectNodeRoutes`. Rollback: revert this hunk. If any external system directly addresses pod IPs (none known), it would lose reachability.

Review date 2026-08-02. No cluster changes until Flux reconciles post-merge.