### PR TITLE
fix(monitoring-system): langfuse env repair, VM operator RBAC fix, grafana patch bump

### DIFF
--- a/kubernetes/apps/monitoring-system/grafana/cluster/grafana.yaml
+++ b/kubernetes/apps/monitoring-system/grafana/cluster/grafana.yaml
@@ -110,4 +110,4 @@ spec:
                 limits:
                   memory: 512Mi
   disableDefaultAdminSecret: true
-  version: grafana/grafana:12.3.1
+  version: grafana/grafana:12.3.9

--- a/kubernetes/apps/monitoring-system/langfuse/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring-system/langfuse/app/helmrelease.yaml
@@ -24,6 +24,11 @@ spec:
               repository: ghcr.io/langfuse/langfuse
               tag: 4.2.0
             env:
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: langfuse-pguser
+                    key: uri
               LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: &bucket_endpoint
                 valueFrom:
                   configMapKeyRef:

--- a/kubernetes/apps/monitoring-system/langfuse/worker/configmap.yaml
+++ b/kubernetes/apps/monitoring-system/langfuse/worker/configmap.yaml
@@ -28,6 +28,6 @@ data:
   LANGFUSE_S3_BATCH_EXPORT_PREFIX: "exports/"
   LANGFUSE_S3_BATCH_EXPORT_REGION: "auto"
   LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE: "true"
-  REDIS: "langfuse-dragonfly.monitoring-system.svc.cluster.local"
+  REDIS_HOST: "langfuse-dragonfly.monitoring-system.svc.cluster.local"
   REDIS_PORT: "6379"
   REDIS_TLS_ENABLED: "false"

--- a/kubernetes/apps/monitoring-system/victoria-metrics/cluster/externalsecret.yaml
+++ b/kubernetes/apps/monitoring-system/victoria-metrics/cluster/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: victoria-metrics-cluster
 spec:
+  refreshInterval: 12h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword

--- a/kubernetes/apps/monitoring-system/victoria-metrics/operator/ocirepository.yaml
+++ b/kubernetes/apps/monitoring-system/victoria-metrics/operator/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.67.0
+    tag: 0.67.1
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-metrics-operator


### PR DESCRIPTION
## Review fixes — monitoring-system (2026-08-02)

- **H7** — `kubernetes/apps/monitoring-system/langfuse/worker/configmap.yaml`: renamed env key `REDIS` → `REDIS_HOST` (value unchanged). Langfuse has no `REDIS` var; `REDIS_HOST` is the documented required key, so the worker was falling back to default localhost Redis. Evidence: https://langfuse.com/self-hosting/deployment/infrastructure/cache (verified: docs list `REDIS_HOST`, no bare `REDIS`).
- **H8** — `kubernetes/apps/monitoring-system/langfuse/app/helmrelease.yaml` (langfuse-web): added `DATABASE_URL` env via `secretKeyRef` name `langfuse-pguser` key `uri`, mirroring `worker/helmrelease.yaml` exactly. Langfuse requires env config on all application containers; langfuse-web had no DB URL.
- **H9** — `kubernetes/apps/monitoring-system/victoria-metrics/operator/ocirepository.yaml`: chart tag `0.67.0` → `0.67.1`. 0.67.0 is missing networkpolicies RBAC, which stops all CR reconciliation. Evidence: https://github.com/VictoriaMetrics/helm-charts/releases/tag/victoria-metrics-operator-0.67.1 (tag `0.67.1` verified present on `ghcr.io/victoriametrics/helm-charts/victoria-metrics-operator`).
- **M8** — `kubernetes/apps/monitoring-system/grafana/cluster/grafana.yaml`: `grafana/grafana:12.3.1` → `12.3.9` (latest 12.3 patch; verified `12.3.9` is the newest `12.3.x` semver tag on Docker Hub). Evidence: https://github.com/grafana/grafana/releases
- **M9** — `kubernetes/apps/monitoring-system/kube-state-metrics/app/ocirepository.yaml`: tag `8.0.0` → `8.1.3` (chart-only fixes). Evidence: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/Chart.yaml — **note: already applied on `main`** by Renovate PR #3097 (merge commit b56d5971); this branch was cut from `origin/main` post-merge, so no diff results. Included here for completeness.
- **LOW** — `kubernetes/apps/monitoring-system/victoria-metrics/cluster/externalsecret.yaml`: added `refreshInterval: 12h` (was the only ExternalSecret in the repo missing it).

**Note on BullMQ:** `LANGFUSE_BULLMQ_SKIP_REDIS_VERSION_CHECK` was intentionally NOT added — it is only needed if BullMQ runtime errors appear against the Dragonfly-backed Redis; add it then, not preemptively.

Review date 2026-08-02. No cluster changes until Flux reconciles post-merge.
