### PR TITLE
fix(networking-system): agentgateway parameters ref, kgateway tracing field, scrape ports

### DIFF
--- a/kubernetes/apps/networking-system/agentgateway/config/gateway/gatewayparams.yaml
+++ b/kubernetes/apps/networking-system/agentgateway/config/gateway/gatewayparams.yaml
@@ -1,7 +1,7 @@
 ---
-# yaml-language-server: $schema=https://soulwhisper.github.io/k8s-schemas/gateway.kgateway.dev/gatewayparameters_v1alpha1.json
-apiVersion: gateway.kgateway.dev/v1alpha1
-kind: GatewayParameters
+# yaml-language-server: $schema=https://soulwhisper.github.io/k8s-schemas/agentgateway.dev/agentgatewayparameters_v1alpha1.json
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayParameters
 metadata:
   name: agentgateway-params
 spec:

--- a/kubernetes/apps/networking-system/agentgateway/config/gateway/podmonitor.yaml
+++ b/kubernetes/apps/networking-system/agentgateway/config/gateway/podmonitor.yaml
@@ -10,7 +10,7 @@ spec:
     matchNames:
       - networking-system
   podMetricsEndpoints:
-    - port: http-monitoring
+    - port: metrics
       path: /metrics
       honorLabels: true
   selector:

--- a/kubernetes/apps/networking-system/externaldns/app/helmrelease.yaml
+++ b/kubernetes/apps/networking-system/externaldns/app/helmrelease.yaml
@@ -14,7 +14,6 @@ spec:
     fullnameOverride: *name
     domainFilters: ["noirprime.com"]
     extraArgs:
-      - --webhook-provider-url=http://localhost:8888
       - --gateway-name=kgateway-internal
     podAnnotations:
       reloader.stakater.com/auto: "true"
@@ -43,7 +42,7 @@ spec:
           - name: DRY_RUN
             value: "false"
           - name: LOG_LEVEL
-            value: debug
+            value: info
           - name: SERVER_HOST
             value: 0.0.0.0
           - name: ADGUARD_URL
@@ -68,4 +67,5 @@ spec:
     sources:
       - gateway-httproute
       - service
+    txtOwnerId: "home-ops"
     txtPrefix: "k8s-int."

--- a/kubernetes/apps/networking-system/kgateway/app/servicemonitor.yaml
+++ b/kubernetes/apps/networking-system/kgateway/app/servicemonitor.yaml
@@ -13,6 +13,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: *name
   endpoints:
-    - port: http
+    - port: metrics
       path: /metrics
       honorLabels: true

--- a/kubernetes/apps/networking-system/kgateway/config/gatewayextension.yaml
+++ b/kubernetes/apps/networking-system/kgateway/config/gatewayextension.yaml
@@ -5,7 +5,6 @@ kind: GatewayExtension
 metadata:
   name: authentik-ext-auth
 spec:
-  type: ExtAuth
   extAuth:
     httpService:
       backendRef:

--- a/kubernetes/apps/networking-system/kgateway/config/https-redirect.yaml
+++ b/kubernetes/apps/networking-system/kgateway/config/https-redirect.yaml
@@ -4,8 +4,6 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: https-redirect
-  annotations:
-    external-dns.alpha.kubernetes.io/controller: none
 spec:
   parentRefs:
     - name: kgateway-internal

--- a/kubernetes/apps/networking-system/kgateway/config/listenerpolicy.yaml
+++ b/kubernetes/apps/networking-system/kgateway/config/listenerpolicy.yaml
@@ -23,10 +23,10 @@ spec:
           openTelemetry:
             serviceName: kgateway
             grpcService:
-              backendRefs:
-                - name: opentelemetry-collector
-                  namespace: monitoring-system
-                  port: 4317
+              backendRef:
+                name: opentelemetry-collector
+                namespace: monitoring-system
+                port: 4317
         spawnUpstreamSpan: true
         clientSampling: 100
         randomSampling: 100


### PR DESCRIPTION
Applies the networking-system review fixes. One atomic commit, no cluster-mutating commands run.

- **H1** — `agentgateway/config/gateway/gatewayparams.yaml`: `GatewayParameters` (`gateway.kgateway.dev/v1alpha1`) → `AgentgatewayParameters` (`agentgateway.dev/v1alpha1`). The kgateway CRD is the wrong API for agentgateway; the Gateway's `infrastructure.parametersRef` already points at `agentgateway.dev`/`AgentgatewayParameters`, so this resource was never adopted. Flat spec fields (`deployment`, `podDisruptionBudget`, `rawConfig`, `service`, `resources`) all verified present in AgentgatewayParametersSpec of the pinned chart (agentgateway 1.4.1). Evidence: https://agentgateway.dev/docs/kubernetes/latest/reference/api/ and https://soulwhisper.github.io/k8s-schemas/agentgateway.dev/agentgatewayparameters_v1alpha1.json (schema comment updated; HTTP 200).
- **H2** — `kgateway/config/listenerpolicy.yaml`: tracing provider `openTelemetry.grpcService.backendRefs` (list) → `backendRef` (single object, same name/namespace/port). CRD requires the singular field. Evidence: `CommonGrpcService.BackendRef gwv1.BackendRef` in https://github.com/kgateway-dev/kgateway/blob/v2.4.1/api/v1alpha1/kgateway/listener_policy_types.go (pinned kgateway 2.4.1).
- **M5** — `agentgateway/config/gateway/podmonitor.yaml`: podMetricsEndpoints port `http-monitoring` → `metrics`. The agentgateway proxy pods only expose container ports `metrics/15020` and `ui/15000` (see gatewayparams.yaml), so the PodMonitor matched nothing.
- **M6** — `kgateway/app/servicemonitor.yaml`: endpoint port `http` → `metrics`. The pinned kgateway chart 2.4.1 controller Service exposes only `grpc-xds`, `health`, `metrics` (https://github.com/kgateway-dev/kgateway/blob/v2.4.1/install/helm/kgateway/templates/service.yaml); no `http` port exists, so the ServiceMonitor matched nothing.
- **NET-6** — `kgateway/config/gatewayextension.yaml`: removed deprecated `type: ExtAuth`. In v2.4.1 the field is marked `Deprecated: Setting this field has no effect` — type is inferred from which config block is present (`ExactlyOneOf=extAuth;extProc;rateLimit;jwt;oauth2`). Evidence: https://github.com/kgateway-dev/kgateway/blob/v2.4.1/api/v1alpha1/kgateway/gateway_extensions_types.go
- **NET-7** — `externaldns/app/helmrelease.yaml`: added `txtOwnerId: "home-ops"` alongside `txtPrefix` (both keys exist in the pinned external-dns chart 1.21.1 values); removed redundant `--webhook-provider-url=http://localhost:8888` (upstream flag default, https://github.com/kubernetes-sigs/external-dns/blob/v0.20.0/pkg/apis/externaldns/types.go); webhook sidecar `LOG_LEVEL` debug → info.
- **NET-9** — `kgateway/config/https-redirect.yaml`: removed dead `external-dns.alpha.kubernetes.io/controller: none` annotation — the route has no hostnames, so external-dns never generates records from it; the annotation was a no-op.

**NET-8 (design note, no change):** the agentgateway Gateway intentionally exposes only an HTTP listener on port 80. agentgateway is an internal AI/MCP proxy reached through kgateway, which terminates TLS at the edge; adding an HTTPS listener to agentgateway would require duplicating cert management for no security gain on the cluster-internal hop. Left as-is.

Review date 2026-08-02; no cluster changes until Flux reconciles post-merge.
