### PR TITLE
fix(kube-system): k8tz 0.20.0 via upstream OCI (mirror lagging)

### DIFF
--- a/kubernetes/apps/kube-system/k8tz/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/k8tz/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.19.0
-  url: oci://ghcr.io/home-operations/charts-mirror/k8tz
+    tag: 0.20.0
+  url: oci://ghcr.io/k8tz/k8tz/charts/k8tz


### PR DESCRIPTION
## Why

#3101 originally bumped k8tz 0.19.0 → 0.20.0 (security-flagged release, no breaking changes) but CI failed: `ghcr.io/home-operations/charts-mirror/k8tz` has not mirrored 0.20.0 (latest mirrored tag is 0.19.0, verified via GHCR tags API), so the bump was reverted before merge.

k8tz publishes official OCI charts itself — `oci://ghcr.io/k8tz/k8tz/charts/k8tz:0.20.0` verified present via the GHCR tags API. This PR repoints the OCIRepository from the home-operations mirror to upstream and restores the 0.20.0 bump.

## Changes

- `kubernetes/apps/kube-system/k8tz/app/ocirepository.yaml`: url → `oci://ghcr.io/k8tz/k8tz/charts/k8tz`, tag → `0.20.0`

## Notes

- 0.20.0 changes (tzdata 2026c, imageVolume injection strategy, pod ownership annotation lookup) verified compatible with local values during the 2026-08-02 review.
- Trade-off: k8tz now tracks upstream directly instead of the mirror used by other charts; the mirror was the lag, not the policy.

Reviewed against upstream 2026-08-03; no cluster changes until Flux reconciles post-merge.