### PR TITLE
fix(smarthome-apps): mosquitto password_file subPath, pin HACS, z2m dead config

### DIFF
--- a/kubernetes/apps/smarthome-apps/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/smarthome-apps/home-assistant/app/helmrelease.yaml
@@ -28,12 +28,12 @@ spec:
             image:
               repository: busybox
               tag: "1.38.0"
+            env:
+              HACS_VERSION: "2.0.5"
             command:
               - sh
               - -c
               - |
-                HACS_VERSION=$(wget -qO- https://api.github.com/repos/hacs/integration/releases/latest \
-                  | grep '"tag_name"' | cut -d'"' -f4)
                 wget -O /tmp/hacs.zip \
                   "https://github.com/hacs/integration/releases/download/${HACS_VERSION}/hacs.zip"
                 mkdir -p /config/custom_components/hacs

--- a/kubernetes/apps/smarthome-apps/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/smarthome-apps/mosquitto/app/helmrelease.yaml
@@ -80,4 +80,5 @@ spec:
         name: *name
         globalMounts:
           - path: /etc/mosquitto/password_file
+            subPath: mosquitto
             readOnly: true

--- a/kubernetes/apps/smarthome-apps/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/smarthome-apps/zigbee2mqtt/app/helmrelease.yaml
@@ -38,8 +38,6 @@ spec:
                     name: *name
                     key: zigbee_ext_pan_id
               ZIGBEE2MQTT_CONFIG_ADVANCED_LAST_SEEN: ISO_8601
-              ZIGBEE2MQTT_CONFIG_ADVANCED_LEGACY_API: false
-              ZIGBEE2MQTT_CONFIG_ADVANCED_LEGACY_AVAILABILITY_PAYLOAD: false
               ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_LEVEL: info
               ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_OUTPUT: >-
                 ["console"]
@@ -55,15 +53,11 @@ spec:
                     key: zigbee_pan_id
               ZIGBEE2MQTT_CONFIG_AVAILABILITY_ACTIVE_TIMEOUT: 60
               ZIGBEE2MQTT_CONFIG_AVAILABILITY_PASSIVE_TIMEOUT: 2000
-              ZIGBEE2MQTT_CONFIG_DEVICE_OPTIONS_LEGACY: false
               ZIGBEE2MQTT_CONFIG_DEVICE_OPTIONS_RETAIN: true
-              ZIGBEE2MQTT_CONFIG_EXPERIMENTAL_NEW_API: true
               ZIGBEE2MQTT_CONFIG_FRONTEND_PORT: &httpPort 8080
               ZIGBEE2MQTT_CONFIG_FRONTEND_URL: https://z2m.noirprime.com
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_DISCOVERY_TOPIC: homeassistant
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_EXPERIMENTAL_EVENT_ENTITIES: true
-              ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_LEGACY_ENTITY_ATTRIBUTES: false
-              ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_LEGACY_TRIGGERS: false
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_STATUS_TOPIC: homeassistant/status
               ZIGBEE2MQTT_CONFIG_MQTT_BASE_TOPIC: zigbee2mqtt
               ZIGBEE2MQTT_CONFIG_MQTT_INCLUDE_DEVICE_INFORMATION: true
@@ -81,7 +75,6 @@ spec:
                     name: *name
                     key: mosquitto_password
               ZIGBEE2MQTT_CONFIG_MQTT_VERSION: 5
-              ZIGBEE2MQTT_CONFIG_PERMIT_JOIN: false
               ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: zstack # SLZB-06P10
               ZIGBEE2MQTT_CONFIG_SERIAL_PORT: tcp://zigbee.homelab.internal:6638
               ZIGBEE2MQTT_CONFIG_SERIAL_BAUDRATE: 115200
@@ -102,8 +95,6 @@ spec:
           http:
             primary: true
             port: *httpPort
-          metrics:
-            port: 9000
 
     route:
       app:


### PR DESCRIPTION
## smarthome-apps review fixes (2026-08-03)

### A10 — mosquitto: password_file mount mismatch
**File:** `kubernetes/apps/smarthome-apps/mosquitto/app/helmrelease.yaml`

`mosquitto.conf` sets `password_file /etc/mosquitto/password_file`, but the `mosquitto` secret (single key `mosquitto`, per `externalsecret.yaml`) was mounted as a volume **at** that path — making it a directory with the file landing at `/etc/mosquitto/password_file/mosquitto`, so mosquitto found no password file. Fix: add `subPath: mosquitto` to the secret `globalMounts` entry so the file lands exactly at `/etc/mosquitto/password_file`.

Evidence: Kubernetes secret volume semantics (each key becomes a file under the mount path) — https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod

**Not done (deliberately):** bumping eclipse-mosquitto to 2.1.x. 2.1 deprecates `password_file` in favour of per-listener `password_file`/dynamic security and rejects k8s secret symlink layouts without `MOSQUITTO_UNSAFE_ALLOW_SYMLINKS=true` — that is a separate planned change. Evidence: https://github.com/eclipse-mosquitto/mosquitto/blob/master/ChangeLog.txt

### SH-4 — home-assistant: pin HACS installer
**File:** `kubernetes/apps/smarthome-apps/home-assistant/app/helmrelease.yaml`

The `hacs-installer` initContainer queried `api.github.com/repos/hacs/integration/releases/latest` at every pod start (unpinned, rate-limit-prone, non-reproducible). Pinned to the latest release `2.0.5` via an `HACS_VERSION` env var; the download URL now uses the pinned value and the GitHub API lookup is removed.

Evidence: latest release verified via GitHub API — https://github.com/hacs/integration/releases/tag/2.0.5

### SH-5 — zigbee2mqtt: delete 7 dead env keys (removed in z2m 2.0.0)
**File:** `kubernetes/apps/smarthome-apps/zigbee2mqtt/app/helmrelease.yaml`

Running image is `2.13.0`; the following options were removed in Zigbee2MQTT 2.0.0 and are dead config: `ZIGBEE2MQTT_CONFIG_EXPERIMENTAL_NEW_API`, `ZIGBEE2MQTT_CONFIG_ADVANCED_LEGACY_API`, `ZIGBEE2MQTT_CONFIG_ADVANCED_LEGACY_AVAILABILITY_PAYLOAD`, `ZIGBEE2MQTT_CONFIG_DEVICE_OPTIONS_LEGACY`, `ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_LEGACY_ENTITY_ATTRIBUTES`, `ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_LEGACY_TRIGGERS`, `ZIGBEE2MQTT_CONFIG_PERMIT_JOIN`.

Evidence: z2m 2.0.0 breaking changes — https://github.com/Koenkk/zigbee2mqtt/discussions/24198

### SH-6 — zigbee2mqtt: remove dead `metrics: 9000` service port
**File:** `kubernetes/apps/smarthome-apps/zigbee2mqtt/app/helmrelease.yaml`

Nothing in the container listens on 9000 and nothing scrapes it — removed the dead port.

---
Review date 2026-08-03. All YAML validated with `yq`. Changes apply via Flux/doco-cd reconcile post-merge.