### PR TITLE
fix(selfhosted-apps): miniflux DSN, netbox SSO pipeline, firecrawl playwright URL, dead keys

### DIFF
--- a/kubernetes/apps/selfhosted-apps/bambuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted-apps/bambuddy/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/maziggy/bambuddy
-              tag: 1.2.5
+              tag: 1.2.5.2
             env:
               PORT: &httpPort 8000
             probes:

--- a/kubernetes/apps/selfhosted-apps/firecrawl/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted-apps/firecrawl/app/configmap.yaml
@@ -9,13 +9,13 @@ data:
   USE_DB_AUTHENTICATION: "false"
   SENTRY_ENVIRONMENT: "production"
   ENV: "production"
-  LOGGING_LEVEL: "DEBUG"
+  LOGGING_LEVEL: "INFO"
   IS_KUBERNETES: "true"
   # Database
   REDIS_URL: "redis://firecrawl-database-dragonfly.selfhosted-apps.svc.cluster.local:6379"
   REDIS_RATE_LIMIT_URL: "redis://firecrawl-database-dragonfly.selfhosted-apps.svc.cluster.local:6379"
   # Service
-  PLAYWRIGHT_MICROSERVICE_URL: "http://firecrawl.selfhosted-apps.svc.cluster.local:3000"
+  PLAYWRIGHT_MICROSERVICE_URL: "http://firecrawl-playwright.selfhosted-apps.svc.cluster.local:3000"
   MAX_CONCURRENT_JOBS: "2"
   NUM_WORKERS_PER_QUEUE: "2"
   CRAWL_CONCURRENT_REQUESTS: "2"

--- a/kubernetes/apps/selfhosted-apps/firecrawl/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted-apps/firecrawl/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
           app:
             image:
               repository: ghcr.io/firecrawl/firecrawl
-              tag: 2.11.169@sha256:2d6d572e26deee4d5749f100627682ff4b386b069126d3ae27b1abb70b32bd22
+              tag: 2.11.170@sha256:1ea9b523bc907ef0a45dd3bc4f298fba85be3be76af99232af3ade29897ec3ce
             command: ["node"]
             args:
               - --max-old-space-size=512
@@ -105,7 +105,7 @@ spec:
           app:
             image:
               repository: ghcr.io/firecrawl/firecrawl
-              tag: 2.11.169@sha256:2d6d572e26deee4d5749f100627682ff4b386b069126d3ae27b1abb70b32bd22
+              tag: 2.11.170@sha256:1ea9b523bc907ef0a45dd3bc4f298fba85be3be76af99232af3ade29897ec3ce
             command: ["node"]
             args:
               - --max-old-space-size=1024

--- a/kubernetes/apps/selfhosted-apps/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted-apps/homepage/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               repository: ghcr.io/gethomepage/homepage
               tag: v1.13.2
             env:
-              HOMEPAGE_ALLOWED_HOSTS: "*"
+              HOMEPAGE_ALLOWED_HOSTS: "home.noirprime.com"
             envFrom:
               - secretRef:
                   name: *name

--- a/kubernetes/apps/selfhosted-apps/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted-apps/karakeep/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
               repository: getmeili/meilisearch
               tag: v1.51.0
             args:
-              - --experimental-dumpless-upgrade
+              - --upgrade-db
             env:
               MEILI_NO_ANALYTICS: true
             envFrom:

--- a/kubernetes/apps/selfhosted-apps/miniflux/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted-apps/miniflux/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
             env:
               RUN_MIGRATIONS: "true"
               DISABLE_LOCAL_AUTH: "true"
-              DB_POSTGRESQL_DATABASE:
+              DATABASE_URL:
                 valueFrom:
                   secretKeyRef:
                     name: miniflux-pguser

--- a/kubernetes/apps/selfhosted-apps/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted-apps/netbox/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
               "social_core.pipeline.social_auth.associate_user",
               "social_core.pipeline.social_auth.load_extra_data",
               "social_core.pipeline.user.user_details",
-              "netbox.sso_pipeline_roles.set_role",
+              "netbox.sso_pipeline_roles.set_roles",
             ]
     extraEnvs:
       - name: SOCIAL_AUTH_OIDC_KEY

--- a/kubernetes/apps/selfhosted-apps/rsshub/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted-apps/rsshub/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
           app:
             image:
               repository: ghcr.io/diygod/rsshub
-              tag: chromium-bundled-2026-04-06
+              tag: chromium-bundled-2026-08-03
             env:
               NODE_ENV: "production"
               NODE_OPTIONS: "--max-old-space-size=1536"

--- a/kubernetes/apps/selfhosted-apps/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted-apps/searxng/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/searxng/searxng
-              tag: 2026.4.24-a7ac696b4
+              tag: 2026.8.1-8892414dc
             env:
               SEARXNG_PORT: &port 8080
               SEARXNG_BASE_URL: https://search.noirprime.com

--- a/kubernetes/apps/selfhosted-apps/stirling-pdf/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted-apps/stirling-pdf/app/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
 data:
   # ref:https://docs.stirlingpdf.com/Configuration
   # : Common Settings
-  MODE: "Both"
   DISABLE_ADDITIONAL_FEATURES: "false"
   JAVA_TOOL_OPTIONS: "-Xms512m -Xmx4g"
   SYSTEM_MAXFILESIZE: "2000" # MB
@@ -36,10 +35,7 @@ data:
   SECURITY_VALIDATION_REVOCATION_MODE: "ocsp+crl"
   SECURITY_VALIDATION_REVOCATION_HARDFAIL: "false"
   # : JWT Authentication
-  SECURITY_JWT_PERSISTENCE: "true"
-  SECURITY_JWT_ENABLEKEYROTATION: "true"
   SECURITY_JWT_ENABLEKEYCLEANUP: "true"
-  SECURITY_JWT_KEYRETENTIONDAYS: "7"
   # : Email Configuration
   MAIL_ENABLED: "false"
   MAIL_ENABLEINVITES: "false"


### PR DESCRIPTION
Applies the 2026-08-03 review fixes for the `selfhosted-apps` namespace. Each fix was verified against upstream docs/source at the pinned version before editing.

## Applied fixes

| Finding | File | Change | Evidence |
|---|---|---|---|
| A4 | `miniflux/app/helmrelease.yaml` | Env `DB_POSTGRESQL_DATABASE` → `DATABASE_URL`. Miniflux has no `DB_POSTGRESQL_DATABASE` option; the CNPG pguser `uri` value is already a full DSN, which is exactly what `DATABASE_URL` expects. | https://miniflux.app/docs/configuration.html (`DATABASE_URL` listed; no `DB_POSTGRESQL*` option exists) |
| A5 | `netbox/app/helmrelease.yaml` | `SOCIAL_AUTH_PIPELINE` entry `netbox.sso_pipeline_roles.set_role` → `netbox.sso_pipeline_roles.set_roles`, matching the function actually defined in `netbox/app/configmap.yaml`. `add_groups`/`remove_groups` left as-is (may be used later). The configmap import `from netbox.authentication import Group` was verified against netbox 4.6 source: `netbox/authentication/__init__.py` does `from users.models import Group, ...`, so `Group` is importable from that module — **no import change needed**. | https://github.com/netbox-community/netbox/blob/v4.6.7/netbox/netbox/authentication/__init__.py |
| A6 | `firecrawl/app/configmap.yaml` | `PLAYWRIGHT_MICROSERVICE_URL` → `http://firecrawl-playwright.selfhosted-apps.svc.cluster.local:3000` (verified: the helmrelease defines a `playwright` service on the `firecrawl-playwright` controller, so app-template renders service `firecrawl-playwright`; the old URL pointed at the API service). `LOGGING_LEVEL` `DEBUG` → `INFO`. | `firecrawl/app/helmrelease.yaml` service definitions |
| A6 | `firecrawl/app/helmrelease.yaml` | Image `2.11.169` → `2.11.170` (api + nuq-worker), digest updated to `sha256:1ea9b523bc907ef0a45dd3bc4f298fba85be3be76af99232af3ade29897ec3ce` resolved from the GHCR manifests API. | https://ghcr.io/v2/firecrawl/firecrawl/manifests/2.11.170 |
| — | `stirling-pdf/app/configmap.yaml` | Deleted dead keys against pinned `2.14.2-fat`: `SECURITY_JWT_PERSISTENCE` (Jwt field is `enableKeystore`, no `persistence`), `SECURITY_JWT_ENABLEKEYROTATION` (no such field), `SECURITY_JWT_KEYRETENTIONDAYS` (computed getter, not settable), `MODE` (legacy pre-1.0 var, no root `mode` property). | https://github.com/Stirling-Tools/Stirling-PDF/blob/v2.14.2/app/common/src/main/java/stirling/software/common/model/ApplicationProperties.java (class `Security.Jwt`); https://github.com/Stirling-Tools/Stirling-PDF/issues/5131 |
| — | `homepage/app/helmrelease.yaml` | `HOMEPAGE_ALLOWED_HOSTS` `"*"` → `"home.noirprime.com"` (matches the only configured route hostname). | https://gethomepage.dev/installation/k8s/ (HOMEPAGE_ALLOWED_HOSTS) |
| — | `karakeep/app/helmrelease.yaml` | Meilisearch sidecar (v1.51.0) arg `--experimental-dumpless-upgrade` → `--upgrade-db`. Verified in v1.51.0 source: `option.rs` defines `upgrade_db` (`--upgrade-db` / `MEILI_UPGRADE_DB`); the dumpless flag no longer exists at this version. | https://github.com/meilisearch/meilisearch/blob/v1.51.0/crates/meilisearch/src/option.rs |
| — | `bambuddy/app/helmrelease.yaml` | `1.2.5` → `1.2.5.2` (tag confirmed present on GHCR). | https://ghcr.io/v2/maziggy/bambuddy/tags/list |
| — | `rsshub/app/helmrelease.yaml` | `chromium-bundled-2026-04-06` → `chromium-bundled-2026-08-03` (newest dated `chromium-bundled-*` tag per GHCR tags API). | https://ghcr.io/v2/diygod/rsshub/tags/list |
| — | `searxng/app/helmrelease.yaml` | `2026.4.24-a7ac696b4` → `2026.8.1-8892414dc` (newest dated tag per GHCR tags API; the expected `2026.7.30-0be6f8780` also exists but is superseded). | https://ghcr.io/v2/searxng/searxng/tags/list |

## Skipped (verification failed — premise did not hold upstream)

- **honcho** `VECTOR_STORE_TYPE` / `VECTOR_STORE_MIGRATED`: review claimed these are absent from honcho v3 `.env.template`. Verified at the pinned tag `v3.0.12`: both keys are present and documented (`VECTOR_STORE_TYPE=pgvector`, `VECTOR_STORE_MIGRATED=false` under "Vector Store Settings"). **Not dead keys — left unchanged.** https://github.com/plastic-labs/honcho/blob/v3.0.12/.env.template
- **stirling-pdf** `SECURITY_JWT_ENABLEKEYCLEANUP`: review claimed dead, but `enableKeyCleanup` is a live field on `ApplicationProperties.Security.Jwt` in 2.14.2 (also in `settings.yml.template`). **Kept.**

## Not touched (per review scope — unverifiable)

- sillytavern whitelist
- convertx `ALLOW_UNAUTHENTICATED`
- homepage truenas field naming

Review date 2026-08-03. Changes apply via Flux/doco-cd reconcile post-merge.
