### PR TITLE
fix(servitor-apps): mcp image/env repairs, llama pin, ha-mcp 8.0.0

### DIFF
--- a/kubernetes/apps/monitoring-system/grafana/cluster/eso-rbac.yaml
+++ b/kubernetes/apps/monitoring-system/grafana/cluster/eso-rbac.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-store-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - selfsubjectrulesreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-kubernetes-store-role
+subjects:
+  - kind: ServiceAccount
+    name: eso-kubernetes
+    namespace: security-system
+roleRef:
+  kind: Role
+  name: eso-store-role
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/apps/monitoring-system/grafana/cluster/grafanaserviceaccount.yaml
+++ b/kubernetes/apps/monitoring-system/grafana/cluster/grafanaserviceaccount.yaml
@@ -11,4 +11,4 @@ spec:
   isDisabled: false
   tokens:
     - name: *name
-      secretName: token
+      secretName: *name

--- a/kubernetes/apps/monitoring-system/grafana/cluster/kustomization.yaml
+++ b/kubernetes/apps/monitoring-system/grafana/cluster/kustomization.yaml
@@ -6,7 +6,9 @@ resources:
   # app
   - ./grafana.yaml
   - ./grafanadatasource.yaml
+  - ./grafanaserviceaccount.yaml
   # utils
+  - ./eso-rbac.yaml
   - ./httproute.yaml
   - ./servicemonitor.yaml
   - ./poddisruptionbudget.yaml

--- a/kubernetes/apps/security-system/external-secrets/cluster/clustersecretstore.yaml
+++ b/kubernetes/apps/security-system/external-secrets/cluster/clustersecretstore.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   provider:
     kubernetes:
+      # Source namespace for all secrets served by this store.
+      remoteNamespace: monitoring-system
       server:
         caProvider:
           type: ConfigMap
@@ -15,3 +17,4 @@ spec:
       auth:
         serviceAccount:
           name: "eso-kubernetes"
+          namespace: security-system

--- a/kubernetes/apps/servitor-apps/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/servitor-apps/hermes-agent/app/helmrelease.yaml
@@ -34,6 +34,10 @@ spec:
               repository: ghcr.io/soulwhisper/hermes-extras
               tag: "2026.08.02"
             command: ["/bin/sh", "/app/install.sh"]
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+              readOnlyRootFilesystem: true
         containers:
           app:
             image:

--- a/kubernetes/apps/servitor-apps/llama/app/helmrelease.yaml
+++ b/kubernetes/apps/servitor-apps/llama/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           app:
             image:
               repository: ghcr.io/ggml-org/llama.cpp
-              tag: server
+              tag: server-b10200
             env:
               LLAMA_ARG_HOST: "0.0.0.0"
               LLAMA_ARG_PORT: &port 8080

--- a/kubernetes/apps/servitor-apps/mcp/firecrawl/app/mcpserver.yaml
+++ b/kubernetes/apps/servitor-apps/mcp/firecrawl/app/mcpserver.yaml
@@ -7,19 +7,15 @@ metadata:
 spec:
   groupRef:
     name: external
-  image: ghcr.io/firecrawl/firecrawl-mcp-server:latest
+  image: ghcr.io/firecrawl/firecrawl-mcp-server:latest@sha256:4753735de5ee894ea73d985fab2431626860d8f80dfb62df2582945aa8d2f829
   env:
     - name: PORT
-      value: &port 3000
+      value: "3000"
     - name: FIRECRAWL_API_URL
       value: "http://firecrawl.selfhosted-apps.svc.cluster.local:3002"
-    - name: FIRECRAWL_RETRY_MAX_ATTEMPTS
-      value: "10"
-    - name: FIRECRAWL_RETRY_INITIAL_DELAY
-      value: "500"
-    - name: TTP_STREAMABLE_SERVER
+    - name: HTTP_STREAMABLE_SERVER
       value: "true"
-  mcpPort: *port
+  mcpPort: 3000
   resources:
     requests:
       cpu: 100m

--- a/kubernetes/apps/servitor-apps/mcp/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/servitor-apps/mcp/grafana/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://soulwhisper.github.io/k8s-schemas/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name mcp-grafana-sa
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes
+  target:
+    name: *name
+  data:
+    - secretKey: token
+      remoteRef:
+        # The GrafanaServiceAccount CR lives in monitoring-system (grafana-operator
+        # requires it in the Grafana instance's namespace and writes the token
+        # Secret into the CR's namespace), so the token is synced here from
+        # monitoring-system via the `kubernetes` ClusterSecretStore.
+        key: *name
+        property: token

--- a/kubernetes/apps/servitor-apps/mcp/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/servitor-apps/mcp/grafana/app/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   # app
   - ./mcpserver.yaml
   # utils
-  - ./grafanaserviceaccount.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/servitor-apps/mcp/home-assistant/app/mcpserver.yaml
+++ b/kubernetes/apps/servitor-apps/mcp/home-assistant/app/mcpserver.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   groupRef:
     name: internal-rw
-  image: ghcr.io/homeassistant-ai/ha-mcp:7.14.2
+  image: ghcr.io/homeassistant-ai/ha-mcp:8.0.0
   podTemplateSpec:
     spec:
       containers:

--- a/kubernetes/apps/servitor-apps/mcp/victoria-logs/app/mcpserver.yaml
+++ b/kubernetes/apps/servitor-apps/mcp/victoria-logs/app/mcpserver.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   groupRef:
     name: internal-ro
-  image: ghcr.io/victoriametrics-community/mcp-victorialogs:7.1.0
+  image: ghcr.io/victoriametrics-community/mcp-victorialogs:v1.8.0@sha256:d2a0826def2b4a25f0e26c8d3e7f28f02117f90b6b4c99f2c354421f6dee30d1
   env:
     - name: VL_INSTANCE_ENTRYPOINT
       value: "http://victoria-logs-server.monitoring-system.svc.cluster.local:9428"


### PR DESCRIPTION
Applies the servitor-apps findings from the 2026-08-03 review. All changes apply via Flux reconcile post-merge.

## A1 — mcp/victoria-logs: dangling image tag
`ghcr.io/victoriametrics-community/mcp-victorialogs:7.1.0` returns 404 from the GHCR manifest API (dangling tag). Repinned to `v1.8.0` with digest `sha256:d2a0826def2b4a25f0e26c8d3e7f28f02117f90b6b4c99f2c354421f6dee30d1` (resolved via `https://ghcr.io/v2/victoriametrics-community/mcp-victorialogs/manifests/v1.8.0`). Env keys re-checked against the v1.8.0 README — `VL_INSTANCE_ENTRYPOINT` / `MCP_SERVER_MODE` / `MCP_LISTEN_ADDR` are unchanged, no env adjustments needed.
- Evidence: https://github.com/VictoriaMetrics-Community/mcp-victorialogs/blob/v1.8.0/README.md#configuration

## A2 — mcp/firecrawl: env typo, dead keys, mutable tag
- Fixed `TTP_STREAMABLE_SERVER` → `HTTP_STREAMABLE_SERVER` (verified in `src/index.ts`: `process.env.HTTP_STREAMABLE_SERVER === 'true'`).
- Deleted dead keys `FIRECRAWL_RETRY_MAX_ATTEMPTS` / `FIRECRAWL_RETRY_INITIAL_DELAY` — only referenced in legacy docs (`src/legacy/index.md`, `CHANGELOG.md`), not in the active server code.
- Digest-pinned `ghcr.io/firecrawl/firecrawl-mcp-server:latest` → `latest@sha256:4753735de5ee894ea73d985fab2431626860d8f80dfb62df2582945aa8d2f829` (resolved via GHCR manifest API).
- Evidence: https://github.com/firecrawl/firecrawl-mcp-server/blob/main/src/index.ts

## A3 — mcp/grafana: SA token secret name + namespace gap
Two problems, both fixed:
1. **Name mismatch**: `GrafanaServiceAccount.spec.tokens[].secretName` was `token`, but the MCPServer references Secret `mcp-grafana-sa`. Aligned: `secretName: mcp-grafana-sa` (token data key remains `token`, confirmed in grafana-operator source).
2. **Namespace gap** (worse than the review suspected): grafana-operator v5.24.0 `lookupGrafana` resolves the Grafana instance in the **GrafanaServiceAccount CR's own namespace** (`client.ObjectKey{Namespace: cr.Namespace, ...}`) and `buildTokenSecret` also writes the token Secret into `cr.Namespace`. With the CR in `servitor-apps` and the Grafana instance in `monitoring-system`, the operator never found the instance and **no token secret was ever created anywhere**. There is no `instanceSelector`/cross-namespace option in v5.24 (`grafanaserviceaccount_types.go`).
   Fix:
   - Moved `grafanaserviceaccount.yaml` to `kubernetes/apps/monitoring-system/grafana/cluster/` (co-located with the Grafana instance; token Secret `mcp-grafana-sa` now created in `monitoring-system`).
   - Added an `ExternalSecret` in `mcp/grafana/app/` syncing `monitoring-system/mcp-grafana-sa` key `token` into `servitor-apps/mcp-grafana-sa` via the existing ClusterSecretStore `kubernetes`.
   - Scoped the (previously consumer-less) `kubernetes` ClusterSecretStore: set `remoteNamespace: monitoring-system` (kubebuilder default was `default`, which served nothing) and pinned `auth.serviceAccount.namespace: security-system` (previously referent-resolved, i.e. only usable from namespaces containing an `eso-kubernetes` SA).
   - Added `Role`/`RoleBinding` for SA `security-system/eso-kubernetes` (secrets get/list/watch + selfsubjectrulesreviews create) in `monitoring-system` — placed in `monitoring-system/grafana/cluster/eso-rbac.yaml` because the external-secrets cluster kustomization has `targetNamespace: security-system`, which would rewrite any manifest there into the wrong namespace.
- Evidence: https://github.com/grafana/grafana-operator/blob/v5.24.0/controllers/serviceaccount_controller.go (`lookupGrafana` ~L250, `buildTokenSecret` ~L790, `secret.Data["token"]` L832), https://github.com/grafana/grafana-operator/blob/v5.24.0/api/v1beta1/grafanaserviceaccount_types.go, https://github.com/external-secrets/external-secrets/blob/main/docs/provider/kubernetes.md

## llama — mutable tag pinned
`ghcr.io/ggml-org/llama.cpp:server` → `server-b10200` (immutable build tag; verified resolving via GHCR manifest API, digest `sha256:8b7f05d7d14d040463ef9191b24da93724574abd6bfea9bf12899100f62e98db`).

## mcp/home-assistant — ha-mcp 7.14.2 → 8.0.0
Config-compatible: `fastmcp-http.json` at v8.0.0 still serves port 8086 (`mcpPort` unchanged); the removed `ha-mcp-sse` variant is not used here.
- Evidence: https://github.com/homeassistant-ai/ha-mcp/blob/v8.0.0/fastmcp-http.json
- **Post-merge note**: ha-mcp v8 reworked the tool security policy to ANY-match — re-check tool exposure (enabled/disabled tool sets) after merge.

## LOW — hermes-agent initContainer hardening
`hermes-extras` initContainer now mirrors the main container's securityContext: `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities: drop [ALL]`.

---
Review date 2026-08-03, changes apply via Flux/doco-cd reconcile post-merge.