### PR TITLE
chore(talos): migrate prod config to v1.14 multi-document format [blocked: v1.14 GA]

### DIFF
--- a/infrastructure/talos/prod/10-general.yaml
+++ b/infrastructure/talos/prod/10-general.yaml
@@ -1,165 +1,42 @@
 ---
+# v1alpha1 survivors (NOT deprecated in Talos v1.14): cluster.etcd, machine.features.nodeAddressSortAlgorithm, machine.install.
+# Deprecated v1alpha1 fields moved to multi-document patches: 12-k8s.yaml (cluster.* + machine.{kubelet,nodeLabels,features.kubernetesTalosAPIAccess}) and 14-host.yaml (machine.{sysctls,files,pods}).
+# machine.features.hostDNS is deprecated in v1.14 ("Use ResolverConfig document instead") and lives in the ResolverConfig document below.
 cluster:
-  allowSchedulingOnControlPlanes: true
-  apiServer:
-    admissionControl:
-      $patch: delete
-  coreDNS:
-    disabled: true
-  etcd:
+  etcd: # extraArgs + advertisedSubnets remain valid v1alpha1 fields (only the legacy singular `subnet` field is deprecated)
     extraArgs:
       quota-backend-bytes: 8589934592
     advertisedSubnets:
       - 10.10.0.0/24
-  discovery:
-    enabled: true
-    registries:
-      kubernetes:
-        disabled: true
-      service:
-        endpoint: http://10.10.0.100:9300
-  network:
-    cni:
-      name: none
-    podSubnets:
-      - 10.100.0.0/17
-    serviceSubnets:
-      - 10.100.128.0/17
-  proxy:
-    disabled: true
-  scheduler:
-    config:
-      apiVersion: kubescheduler.config.k8s.io/v1
-      kind: KubeSchedulerConfiguration
-      profiles:
-        - schedulerName: default-scheduler
-          plugins:
-            score:
-              disabled:
-                - name: ImageLocality
-                - name: SelectorSpread
-          pluginConfig:
-            - name: PodTopologySpread
-              args:
-                defaultingType: List
-                defaultConstraints:
-                  - maxSkew: 1
-                    topologyKey: kubernetes.io/hostname
-                    whenUnsatisfiable: ScheduleAnyway
-                    matchLabelKeys:
-                      - pod-template-hash
-                      - controller-revision-hash
 machine:
   features:
-    nodeAddressSortAlgorithm: v2
-    hostDNS:
-      enabled: true
-      forwardKubeDNSToHost: true
-      resolveMemberNames: true
-    kubernetesTalosAPIAccess:
-      enabled: true
-      allowedRoles:
-        - os:admin
-        - os:etcd:backup
-      allowedKubernetesNamespaces:
-        - gitops-system
-  files:
-    - op: create
-      path: /etc/cri/conf.d/20-customization.part
-      content: |
-        [plugins]
-          [plugins."io.containerd.cri.v1.images"]
-            discard_unpacked_layers = false
-          [plugins."io.containerd.cri.v1.runtime"]
-            device_ownership_from_security_context = true
-          [plugins."io.containerd.grpc.v1.cri"]
-            enable_unprivileged_ports = true
-            enable_unprivileged_icmp = true
-  install:
+    nodeAddressSortAlgorithm: v2 # not deprecated in v1.14, stays here
+  install: # not deprecated in v1.14, stays here
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
     image: factory.talos.dev/metal-installer/88a80a46089706032472a6cb4ecbe8e19a6774d3520869dec3a203631eadbc21:v1.13.7
     grubUseUKICmdline: true
     diskSelector:
       model: "SQF-C3AV1-256GDEDM"
-  kubelet:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    image: ghcr.io/siderolabs/kubelet:v1.36.3
-    nodeIP:
-      validSubnets:
-        - 10.10.0.0/24
-  nodeLabels:
-    topology.kubernetes.io/region: main
-    topology.kubernetes.io/zone: homelab
-    intel.feature.node.kubernetes.io/gpu: "true"
-  sysctls:
-    # moviepilot requires high inotify limits for media library watching (~500k files)
-    fs.inotify.max_user_watches: 1048576 # default 8192; recommended 1048576 supports large media libraries
-    fs.inotify.max_user_instances: 8192 # default 128; matches watches for consistency
-    # ARP table size for BGP+Cilium: large cluster peering table requires expanded neighbor cache
-    net.ipv4.neigh.default.gc_thresh1: 1024 # GC start threshold (default 128)
-    net.ipv4.neigh.default.gc_thresh2: 2048 # GC soft threshold (default 512)
-    net.ipv4.neigh.default.gc_thresh3: 4096 # GC hard threshold (default 1024)
-    # 10G NIC throughput tuning (Intel X710, ice driver)
-    # Reference: https://www.kernel.org/doc/Documentation/networking/scaling.txt
-    net.core.netdev_max_backlog: 16384 # packet queue depth per NIC (default 1000)
-    net.core.somaxconn: 32768 # listen() backlog (default 4096)
-    net.ipv4.tcp_max_syn_backlog: 8192 # SYN queue per socket (default 256)
-    net.core.rmem_max: 134217728 # 128MB socket recv buffer max
-    net.core.wmem_max: 134217728 # 128MB socket send buffer max
-    net.ipv4.tcp_rmem: 4096 87380 134217728 # min/default/max recv buffer
-    net.ipv4.tcp_wmem: 4096 65536 134217728 # min/default/max send buffer
-    # NFS over 10G: increase RPC slot table to avoid NFS client stalls
-    sunrpc.tcp_slot_table_entries: 128 # concurrent RPC calls (default 16)
-    sunrpc.tcp_max_slot_table_entries: 1024 # max concurrent RPC calls
-    user.max_user_namespaces: 11255 # required for rootless containers (UserNamespaces feature)
-    # Writeback tuning for 96GB RAM: reduce kernel dirty page ratio to avoid write storms
-    vm.dirty_background_ratio: 5 # start background writeback at 5% dirty (default 10%)
-    vm.dirty_ratio: 10 # block writes at 10% dirty (default 20%)
-  pods:
-    - apiVersion: v1
-      kind: Pod
-      metadata:
-        name: network-irq-optimizer
-        namespace: kube-system
-      spec:
-        hostNetwork: true
-        hostPID: true
-        containers:
-          - name: irq-optimizer
-            image: alpine
-            securityContext:
-              privileged: true
-            command: ["/bin/sh", "-c"]
-            args:
-              - |
-                # 13900H P-cores (HT enabled) are 0-11. E-cores are 12-19.
-                while true; do
-                  for irq in $(grep 'ice' /proc/interrupts | awk '{print $1}' | tr -d ':'); do
-                    echo "2-11" > /proc/irq/$irq/smp_affinity_list
-                  done
-                  sleep 3600
-                done
-            volumeMounts:
-              - name: proc
-                mountPath: /proc
-        volumes:
-          - name: proc
-            hostPath:
-              path: /proc
 ---
+# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: TimeSyncConfig
 ntp:
   servers:
     - 10.10.0.254
 ---
+# already multi-document in v1.13; in v1.14 it also carries hostDNS (machine.features.hostDNS is deprecated)
+# the generated base ResolverConfig sets hostDNS.{enabled,forwardKubeDNSToHost}: true; only resolveMemberNames needs to be added
 apiVersion: v1alpha1
 kind: ResolverConfig
 nameservers:
   - address: 10.10.0.254
 searchDomains:
   disableDefault: true
+hostDNS:
+  resolveMemberNames: true
 ---
+# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: LinkConfig
 name: lo # fix forwardKubeDNSToHost
@@ -167,6 +44,7 @@ up: true
 addresses:
   - address: 169.254.116.108/32
 ---
+# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: ExtensionServiceConfig
 name: nut-client
@@ -176,10 +54,12 @@ configFiles:
       SHUTDOWNCMD "/sbin/poweroff"
     mountPath: /usr/local/etc/nut/upsmon.conf
 ---
+# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: OOMConfig
 triggerExpression: "false" # disable until 'MemAvailable' implemented
 ---
+# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: VolumeConfig
 name: EPHEMERAL
@@ -188,6 +68,7 @@ provisioning:
     match: system_disk
   maxSize: 80GiB
 ---
+# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: local-hostpath

--- a/infrastructure/talos/prod/10-general.yaml
+++ b/infrastructure/talos/prod/10-general.yaml
@@ -1,32 +1,26 @@
 ---
-# v1alpha1 survivors (NOT deprecated in Talos v1.14): cluster.etcd, machine.features.nodeAddressSortAlgorithm, machine.install.
-# Deprecated v1alpha1 fields moved to multi-document patches: 12-k8s.yaml (cluster.* + machine.{kubelet,nodeLabels,features.kubernetesTalosAPIAccess}) and 14-host.yaml (machine.{sysctls,files,pods}).
-# machine.features.hostDNS is deprecated in v1.14 ("Use ResolverConfig document instead") and lives in the ResolverConfig document below.
 cluster:
-  etcd: # extraArgs + advertisedSubnets remain valid v1alpha1 fields (only the legacy singular `subnet` field is deprecated)
+  etcd:
     extraArgs:
       quota-backend-bytes: 8589934592
     advertisedSubnets:
       - 10.10.0.0/24
 machine:
   features:
-    nodeAddressSortAlgorithm: v2 # not deprecated in v1.14, stays here
-  install: # not deprecated in v1.14, stays here
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    nodeAddressSortAlgorithm:
+  install:
+    # renovate: datasource=github-releases depName=siderolabs/talos
     image: factory.talos.dev/metal-installer/88a80a46089706032472a6cb4ecbe8e19a6774d3520869dec3a203631eadbc21:v1.13.7
     grubUseUKICmdline: true
     diskSelector:
       model: "SQF-C3AV1-256GDEDM"
 ---
-# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: TimeSyncConfig
 ntp:
   servers:
     - 10.10.0.254
 ---
-# already multi-document in v1.13; in v1.14 it also carries hostDNS (machine.features.hostDNS is deprecated)
-# the generated base ResolverConfig sets hostDNS.{enabled,forwardKubeDNSToHost}: true; only resolveMemberNames needs to be added
 apiVersion: v1alpha1
 kind: ResolverConfig
 nameservers:
@@ -36,15 +30,13 @@ searchDomains:
 hostDNS:
   resolveMemberNames: true
 ---
-# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: LinkConfig
-name: lo # fix forwardKubeDNSToHost
+name: kubedns-forward-host-fix
 up: true
 addresses:
   - address: 169.254.116.108/32
 ---
-# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: ExtensionServiceConfig
 name: nut-client
@@ -54,12 +46,10 @@ configFiles:
       SHUTDOWNCMD "/sbin/poweroff"
     mountPath: /usr/local/etc/nut/upsmon.conf
 ---
-# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: OOMConfig
 triggerExpression: "false" # disable until 'MemAvailable' implemented
 ---
-# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: VolumeConfig
 name: EPHEMERAL
@@ -68,7 +58,6 @@ provisioning:
     match: system_disk
   maxSize: 80GiB
 ---
-# already multi-document in v1.13, unchanged
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: local-hostpath

--- a/infrastructure/talos/prod/10-general.yaml
+++ b/infrastructure/talos/prod/10-general.yaml
@@ -7,7 +7,7 @@ cluster:
       - 10.10.0.0/24
 machine:
   features:
-    nodeAddressSortAlgorithm:
+    nodeAddressSortAlgorithm: v2
   install:
     # renovate: datasource=github-releases depName=siderolabs/talos
     image: factory.talos.dev/metal-installer/88a80a46089706032472a6cb4ecbe8e19a6774d3520869dec3a203631eadbc21:v1.13.7

--- a/infrastructure/talos/prod/12-k8s.yaml
+++ b/infrastructure/talos/prod/12-k8s.yaml
@@ -1,0 +1,111 @@
+---
+# Kubernetes control-plane multi-document config (Talos v1.14).
+# Replaces deprecated v1alpha1 cluster.* fields and machine.{kubelet,nodeLabels,features.kubernetesTalosAPIAccess}.
+# Sources: pkg/machinery/config/types/{k8s,cluster} @ v1.14.0-beta.1
+# was: cluster.apiServer.admissionControl $patch: delete
+# deletes the generated default PodSecurity admission plugin config (pkg/machinery/config/types/k8s/admission_control.go);
+# with no KubeAdmissionControlConfig documents left, the apiserver runs without an admission control config file
+apiVersion: v1alpha1
+kind: KubeAdmissionControlConfig
+name: PodSecurity
+$patch: delete
+---
+# was: cluster.network.cni.name: none
+# deletes the generated default Flannel CNI; Cilium is deployed via Helm (pkg/machinery/config/types/k8s/flannel.go)
+apiVersion: v1alpha1
+kind: KubeFlannelCNIConfig
+$patch: delete
+---
+# was: cluster.allowSchedulingOnControlPlanes: true
+# the generated KubeNodeConfig carries the node-role.kubernetes.io/control-plane:NoSchedule taint and map merges
+# cannot remove keys, so the generated document is deleted here and fully re-specified below (without taints)
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+$patch: delete
+---
+# full replacement for the generated KubeNodeConfig (pkg/machinery/config/types/k8s/node.go)
+# labels: the two generated control-plane labels (kept) + former machine.nodeLabels
+# nodeIP: former machine.kubelet.nodeIP.validSubnets
+# no taints = workloads schedule on control planes (parity with allowSchedulingOnControlPlanes: true)
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+nodeIP:
+  validSubnets:
+    - 10.10.0.0/24
+labels:
+  node-role.kubernetes.io/control-plane: ""
+  node.kubernetes.io/exclude-from-external-load-balancers: ""
+  topology.kubernetes.io/region: main
+  topology.kubernetes.io/zone: homelab
+  intel.feature.node.kubernetes.io/gpu: "true"
+---
+# was: machine.kubelet.image (merged into the generated KubeletConfig, which also sets defaultRuntimeSeccompProfileEnabled)
+# source: pkg/machinery/config/types/k8s/kubelet.go
+apiVersion: v1alpha1
+kind: KubeletConfig
+# renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+image: ghcr.io/siderolabs/kubelet:v1.36.3
+---
+# was: cluster.coreDNS.disabled: true (merged into the generated KubeCoreDNSConfig)
+# source: pkg/machinery/config/types/k8s/coredns.go
+apiVersion: v1alpha1
+kind: KubeCoreDNSConfig
+enabled: false
+---
+# was: cluster.proxy.disabled: true (merged into the generated KubeProxyConfig; Cilium kube-proxy replacement)
+# source: pkg/machinery/config/types/k8s/proxy.go
+apiVersion: v1alpha1
+kind: KubeProxyConfig
+enabled: false
+---
+# was: cluster.scheduler.config (merged into the generated KubeSchedulerConfig, which supplies the image)
+# source: pkg/machinery/config/types/k8s/scheduler.go; apiVersion/kind are set automatically by Talos
+apiVersion: v1alpha1
+kind: KubeSchedulerConfig
+config:
+  profiles:
+    - schedulerName: default-scheduler
+      plugins:
+        score:
+          disabled:
+            - name: ImageLocality
+            - name: SelectorSpread
+      pluginConfig:
+        - name: PodTopologySpread
+          args:
+            defaultingType: List
+            defaultConstraints:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+                matchLabelKeys:
+                  - pod-template-hash
+                  - controller-revision-hash
+---
+# was: cluster.network.{podSubnets,serviceSubnets} (subnets replace the generated defaults via merge:"replace")
+# source: pkg/machinery/config/types/k8s/network.go
+apiVersion: v1alpha1
+kind: KubeNetworkConfig
+podSubnets:
+  - 10.100.0.0/17
+serviceSubnets:
+  - 10.100.128.0/17
+---
+# was: machine.features.kubernetesTalosAPIAccess (no generated default; document presence enables the feature)
+# source: pkg/machinery/config/types/k8s/talos_api_access.go
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+allowedRoles:
+  - os:admin
+  - os:etcd:backup
+allowedKubernetesNamespaces:
+  - gitops-system
+---
+# was: cluster.discovery.{enabled,registries.service.endpoint}
+# merged into the generated DiscoveryServiceConfig named "default", overriding the endpoint;
+# the Kubernetes discovery registry is always disabled in v1.14 (KubernetesDiscoveryBackendDisabled, contract.go)
+# source: pkg/machinery/config/types/cluster/discovery_service.go
+apiVersion: v1alpha1
+kind: DiscoveryServiceConfig
+name: default
+endpoint: http://10.10.0.100:9300

--- a/infrastructure/talos/prod/12-k8s.yaml
+++ b/infrastructure/talos/prod/12-k8s.yaml
@@ -1,27 +1,19 @@
 ---
-# Kubernetes control-plane multi-document config (Talos v1.14).
-# Replaces deprecated v1alpha1 cluster.* fields and machine.{kubelet,nodeLabels,features.kubernetesTalosAPIAccess}.
-# Sources: pkg/machinery/config/types/{k8s,cluster} @ v1.14.0-beta.1
-# was: cluster.apiServer.admissionControl $patch: delete
-# deletes the generated default PodSecurity admission plugin config (pkg/machinery/config/types/k8s/admission_control.go);
-# with no KubeAdmissionControlConfig documents left, the apiserver runs without an admission control config file
 apiVersion: v1alpha1
 kind: KubeAdmissionControlConfig
 name: PodSecurity
 $patch: delete
 ---
-# was: cluster.network.cni.name: none
-# deletes the generated default Flannel CNI; Cilium is deployed via Helm (pkg/machinery/config/types/k8s/flannel.go)
 apiVersion: v1alpha1
 kind: KubeFlannelCNIConfig
 $patch: delete
----
-# was: cluster.allowSchedulingOnControlPlanes: true
+# ---
+# was: cluster.allowSchedulingOnControlPlanes: true -- removed ?
 # the generated KubeNodeConfig carries the node-role.kubernetes.io/control-plane:NoSchedule taint and map merges
 # cannot remove keys, so the generated document is deleted here and fully re-specified below (without taints)
-apiVersion: v1alpha1
-kind: KubeNodeConfig
-$patch: delete
+# apiVersion: v1alpha1
+# kind: KubeNodeConfig
+# $patch: delete
 ---
 # full replacement for the generated KubeNodeConfig (pkg/machinery/config/types/k8s/node.go)
 # labels: the two generated control-plane labels (kept) + former machine.nodeLabels
@@ -39,27 +31,19 @@ labels:
   topology.kubernetes.io/zone: homelab
   intel.feature.node.kubernetes.io/gpu: "true"
 ---
-# was: machine.kubelet.image (merged into the generated KubeletConfig, which also sets defaultRuntimeSeccompProfileEnabled)
-# source: pkg/machinery/config/types/k8s/kubelet.go
 apiVersion: v1alpha1
 kind: KubeletConfig
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 image: ghcr.io/siderolabs/kubelet:v1.36.3
 ---
-# was: cluster.coreDNS.disabled: true (merged into the generated KubeCoreDNSConfig)
-# source: pkg/machinery/config/types/k8s/coredns.go
 apiVersion: v1alpha1
 kind: KubeCoreDNSConfig
 enabled: false
 ---
-# was: cluster.proxy.disabled: true (merged into the generated KubeProxyConfig; Cilium kube-proxy replacement)
-# source: pkg/machinery/config/types/k8s/proxy.go
 apiVersion: v1alpha1
 kind: KubeProxyConfig
 enabled: false
 ---
-# was: cluster.scheduler.config (merged into the generated KubeSchedulerConfig, which supplies the image)
-# source: pkg/machinery/config/types/k8s/scheduler.go; apiVersion/kind are set automatically by Talos
 apiVersion: v1alpha1
 kind: KubeSchedulerConfig
 config:
@@ -82,8 +66,6 @@ config:
                   - pod-template-hash
                   - controller-revision-hash
 ---
-# was: cluster.network.{podSubnets,serviceSubnets} (subnets replace the generated defaults via merge:"replace")
-# source: pkg/machinery/config/types/k8s/network.go
 apiVersion: v1alpha1
 kind: KubeNetworkConfig
 podSubnets:
@@ -91,8 +73,6 @@ podSubnets:
 serviceSubnets:
   - 10.100.128.0/17
 ---
-# was: machine.features.kubernetesTalosAPIAccess (no generated default; document presence enables the feature)
-# source: pkg/machinery/config/types/k8s/talos_api_access.go
 apiVersion: v1alpha1
 kind: KubeTalosAPIAccessConfig
 allowedRoles:
@@ -101,10 +81,6 @@ allowedRoles:
 allowedKubernetesNamespaces:
   - gitops-system
 ---
-# was: cluster.discovery.{enabled,registries.service.endpoint}
-# merged into the generated DiscoveryServiceConfig named "default", overriding the endpoint;
-# the Kubernetes discovery registry is always disabled in v1.14 (KubernetesDiscoveryBackendDisabled, contract.go)
-# source: pkg/machinery/config/types/cluster/discovery_service.go
 apiVersion: v1alpha1
 kind: DiscoveryServiceConfig
 name: default

--- a/infrastructure/talos/prod/14-host.yaml
+++ b/infrastructure/talos/prod/14-host.yaml
@@ -1,0 +1,85 @@
+---
+# Host-level multi-document config (Talos v1.14).
+# Replaces deprecated v1alpha1 machine.{sysctls,files,pods}.
+# Sources: pkg/machinery/config/types/{runtime,cri,k8s} @ v1.14.0-beta.1
+# was: machine.sysctls (values are strings in SysctlConfig params)
+# source: pkg/machinery/config/types/runtime/sysctl.go
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  # moviepilot requires high inotify limits for media library watching (~500k files)
+  fs.inotify.max_user_watches: "1048576" # default 8192; recommended 1048576 supports large media libraries
+  fs.inotify.max_user_instances: "8192" # default 128; matches watches for consistency
+  # ARP table size for BGP+Cilium: large cluster peering table requires expanded neighbor cache
+  net.ipv4.neigh.default.gc_thresh1: "1024" # GC start threshold (default 128)
+  net.ipv4.neigh.default.gc_thresh2: "2048" # GC soft threshold (default 512)
+  net.ipv4.neigh.default.gc_thresh3: "4096" # GC hard threshold (default 1024)
+  # 10G NIC throughput tuning (Intel X710, ice driver)
+  # Reference: https://www.kernel.org/doc/Documentation/networking/scaling.txt
+  net.core.netdev_max_backlog: "16384" # packet queue depth per NIC (default 1000)
+  net.core.somaxconn: "32768" # listen() backlog (default 4096)
+  net.ipv4.tcp_max_syn_backlog: "8192" # SYN queue per socket (default 256)
+  net.core.rmem_max: "134217728" # 128MB socket recv buffer max
+  net.core.wmem_max: "134217728" # 128MB socket send buffer max
+  net.ipv4.tcp_rmem: "4096 87380 134217728" # min/default/max recv buffer
+  net.ipv4.tcp_wmem: "4096 65536 134217728" # min/default/max send buffer
+  # NFS over 10G: increase RPC slot table to avoid NFS client stalls
+  sunrpc.tcp_slot_table_entries: "128" # concurrent RPC calls (default 16)
+  sunrpc.tcp_max_slot_table_entries: "1024" # max concurrent RPC calls
+  user.max_user_namespaces: "11255" # required for rootless containers (UserNamespaces feature)
+  # Writeback tuning for 96GB RAM: reduce kernel dirty page ratio to avoid write storms
+  vm.dirty_background_ratio: "5" # start background writeback at 5% dirty (default 10%)
+  vm.dirty_ratio: "10" # block writes at 10% dirty (default 20%)
+---
+# was: machine.files entry /etc/cri/conf.d/20-customization.part (TOML content verbatim)
+# name `customization` is reserved for the legacy file-based part, hence `20-customization`
+# source: pkg/machinery/config/types/cri/customization.go
+apiVersion: v1alpha1
+kind: CRICustomizationConfig
+name: 20-customization
+content: |
+  [plugins]
+    [plugins."io.containerd.cri.v1.images"]
+      discard_unpacked_layers = false
+    [plugins."io.containerd.cri.v1.runtime"]
+      device_ownership_from_security_context = true
+    [plugins."io.containerd.grpc.v1.cri"]
+      enable_unprivileged_ports = true
+      enable_unprivileged_icmp = true
+---
+# was: machine.pods (network-irq-optimizer static pod, pod definition verbatim)
+# source: pkg/machinery/config/types/k8s/static_pod.go
+apiVersion: v1alpha1
+kind: KubeStaticPodConfig
+name: network-irq-optimizer
+pod:
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: network-irq-optimizer
+    namespace: kube-system
+  spec:
+    hostNetwork: true
+    hostPID: true
+    containers:
+      - name: irq-optimizer
+        image: alpine
+        securityContext:
+          privileged: true
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # 13900H P-cores (HT enabled) are 0-11. E-cores are 12-19.
+            while true; do
+              for irq in $(grep 'ice' /proc/interrupts | awk '{print $1}' | tr -d ':'); do
+                echo "2-11" > /proc/irq/$irq/smp_affinity_list
+              done
+              sleep 3600
+            done
+        volumeMounts:
+          - name: proc
+            mountPath: /proc
+    volumes:
+      - name: proc
+        hostPath:
+          path: /proc

--- a/infrastructure/talos/prod/14-host.yaml
+++ b/infrastructure/talos/prod/14-host.yaml
@@ -1,9 +1,4 @@
 ---
-# Host-level multi-document config (Talos v1.14).
-# Replaces deprecated v1alpha1 machine.{sysctls,files,pods}.
-# Sources: pkg/machinery/config/types/{runtime,cri,k8s} @ v1.14.0-beta.1
-# was: machine.sysctls (values are strings in SysctlConfig params)
-# source: pkg/machinery/config/types/runtime/sysctl.go
 apiVersion: v1alpha1
 kind: SysctlConfig
 params:
@@ -31,12 +26,9 @@ params:
   vm.dirty_background_ratio: "5" # start background writeback at 5% dirty (default 10%)
   vm.dirty_ratio: "10" # block writes at 10% dirty (default 20%)
 ---
-# was: machine.files entry /etc/cri/conf.d/20-customization.part (TOML content verbatim)
-# name `customization` is reserved for the legacy file-based part, hence `20-customization`
-# source: pkg/machinery/config/types/cri/customization.go
 apiVersion: v1alpha1
 kind: CRICustomizationConfig
-name: 20-customization
+name: default-patch
 content: |
   [plugins]
     [plugins."io.containerd.cri.v1.images"]
@@ -47,8 +39,6 @@ content: |
       enable_unprivileged_ports = true
       enable_unprivileged_icmp = true
 ---
-# was: machine.pods (network-irq-optimizer static pod, pod definition verbatim)
-# source: pkg/machinery/config/types/k8s/static_pod.go
 apiVersion: v1alpha1
 kind: KubeStaticPodConfig
 name: network-irq-optimizer


### PR DESCRIPTION
Migrates `infrastructure/talos/prod/` machine-config patches to the Talos **v1.14** multi-document config format. Every new document kind was verified against the Talos source at tag `v1.14.0-beta.1` (paths cited below). No `talosctl` validation was run (local talosctl is v1.13); instead the patches were verified end-to-end with a Go harness built on the v1.14.0-beta.1 `pkg/machinery` packages: generate a real v1.14 controlplane config → apply all prod patches in `.justfiles/talos.just` lexical order → `ValidateAsClient` (per-doc validation + v1alpha1 conflict validation) → 40 final-state assertions. All pass. `prek run yamllint` passes.

**DO NOT MERGE until every box is checked:**
- [ ] **Talos v1.14.0 GA tag is released (this was prepared against v1.14.0-beta.1; re-verify schemas if GA diverges)**
- [ ] **Bump installer/kubelet image tags to v1.14-built artifacts (renovate will propose: `factory.talos.dev/metal-installer/...` in `10-general.yaml`, `ghcr.io/siderolabs/kubelet` in `12-k8s.yaml`)**
- [ ] **Regenerate `infrastructure/talos/clusterconfig/` with talosctl v1.14 (`just talos generate prod`) — these patches conflict with a v1.13-generated base**
- [ ] **Run `talosctl -n <node> diff` on every node and review before any `apply`**

## Mapping: old field → new document

| Old (v1alpha1, deprecated in v1.14) | New document | Source @ v1.14.0-beta.1 |
|---|---|---|
| `cluster.apiServer.admissionControl: $patch: delete` | `KubeAdmissionControlConfig` name `PodSecurity` + `$patch: delete` (drops the generated default; zero docs = apiserver runs without admission config file) | `pkg/machinery/config/types/k8s/admission_control.go`, default emitted in `pkg/machinery/config/generate/kubernetes.go` |
| `cluster.coreDNS.disabled: true` | `KubeCoreDNSConfig` `enabled: false` (merges into generated doc) | `pkg/machinery/config/types/k8s/coredns.go` |
| `cluster.discovery` (enabled, k8s registry disabled, service endpoint `http://10.10.0.100:9300`) | `DiscoveryServiceConfig` name `default`, `endpoint: http://10.10.0.100:9300` (merges into generated `default` doc, overrides endpoint). Kubernetes registry backend is always disabled for contract > 1.1 (`KubernetesDiscoveryBackendDisabled`), so no knob needed. Single endpoint kept; v1.14 supports multiple via additional named docs | `pkg/machinery/config/types/cluster/discovery_service.go`, `pkg/machinery/config/contract.go`, `pkg/machinery/config/generate/init.go` |
| `cluster.network.cni.name: none` | `KubeFlannelCNIConfig` + `$patch: delete` (generated by default; no flannel doc + no external CNI manifest = Talos deploys no CNI; Cilium via Helm) | `pkg/machinery/config/types/k8s/flannel.go`, consumer `internal/app/machined/pkg/controllers/k8s/control_plane.go` |
| `cluster.network.{podSubnets,serviceSubnets}` | `KubeNetworkConfig` `podSubnets`/`serviceSubnets` (`merge:"replace"` on the slice fields; `dnsDomain` stays generated default `cluster.local`) | `pkg/machinery/config/types/k8s/network.go` |
| `cluster.proxy.disabled: true` | `KubeProxyConfig` `enabled: false` (merges into generated doc) | `pkg/machinery/config/types/k8s/proxy.go` |
| `cluster.scheduler.config` | `KubeSchedulerConfig` `config:` (payload verbatim minus `apiVersion`/`kind`, which Talos sets automatically; merges into generated doc that supplies the image) | `pkg/machinery/config/types/k8s/scheduler.go` |
| `cluster.allowSchedulingOnControlPlanes: true` | `KubeNodeConfig` without the `node-role.kubernetes.io/control-plane:NoSchedule` taint. The generated KubeNodeConfig carries that taint and map merges cannot remove keys, so the patch deletes the generated document (`$patch: delete`) and fully re-specifies it — generated labels `node-role.kubernetes.io/control-plane` and `node.kubernetes.io/exclude-from-external-load-balancers` are carried over | `pkg/machinery/config/types/k8s/node.go`, generation in `pkg/machinery/config/generate/kubernetes.go`, merge semantics in `pkg/machinery/config/merge/merge.go` + `configpatcher/strategic.go` |
| `machine.kubelet.nodeIP.validSubnets` + `machine.nodeLabels` | `KubeNodeConfig` `nodeIP.validSubnets` / `labels` (in the re-specified document above) | `pkg/machinery/config/types/k8s/node.go` |
| `machine.kubelet.image` (+ renovate comment) | `KubeletConfig` `image:` (merges into generated doc; generated `defaultRuntimeSeccompProfileEnabled: true` preserved). Kubelet image does **not** live in KubeNodeConfig | `pkg/machinery/config/types/k8s/kubelet.go` |
| `machine.features.kubernetesTalosAPIAccess` | `KubeTalosAPIAccessConfig` (presence = enabled; `allowedRoles`/`allowedKubernetesNamespaces` verbatim) | `pkg/machinery/config/types/k8s/talos_api_access.go` |
| `machine.features.hostDNS` | `ResolverConfig` `hostDNS:` — **deviation from the original plan**: v1.14 marks `.machine.features.hostDNS` deprecated ("Use ResolverConfig document instead") and `talosctl gen config` already emits a `ResolverConfig` with `hostDNS.{enabled,forwardKubeDNSToHost}: true`; keeping the v1alpha1 field fails cross-validation. Only `resolveMemberNames: true` is added by our patch | `pkg/machinery/config/types/network/resolver.go`, `pkg/machinery/config/types/v1alpha1/v1alpha1_types.go` (FeaturesConfig), `pkg/machinery/config/generate/init.go` |
| `machine.files` (`/etc/cri/conf.d/20-customization.part`) | `CRICustomizationConfig` name `20-customization` (`customization` is reserved for the legacy file); TOML content verbatim | `pkg/machinery/config/types/cri/customization.go` |
| `machine.sysctls` | `SysctlConfig` `params:` — all 17 sysctls, all comments preserved; values are strings in this document | `pkg/machinery/config/types/runtime/sysctl.go` |
| `machine.pods` (network-irq-optimizer) | `KubeStaticPodConfig` name `network-irq-optimizer`, `pod:` verbatim | `pkg/machinery/config/types/k8s/static_pod.go` |
| `cluster.etcd` (extraArgs, advertisedSubnets) | **stays in v1alpha1** — not deprecated (only the legacy singular `subnet` field is) | `pkg/machinery/config/types/v1alpha1/v1alpha1_types.go` |
| `machine.features.nodeAddressSortAlgorithm` | **stays in v1alpha1** — not deprecated | same |
| `machine.install` (+ renovate comment) | **stays in v1alpha1** — not deprecated | same |

## File layout

- `10-general.yaml` — remaining v1alpha1 (cluster.etcd, features.nodeAddressSortAlgorithm, machine.install) + already-current documents (TimeSync/Resolver/Link/ExtensionService/OOM/Volume/UserVolume)
- `12-k8s.yaml` (new) — Kubernetes control-plane documents + DiscoveryServiceConfig
- `14-host.yaml` (new) — SysctlConfig, CRICustomizationConfig, KubeStaticPodConfig

Lexical order preserved for the `[1-9][0-9]-*.yaml` glob in `.justfiles/talos.just`.

## Notes

- **EPHEMERAL `noexec`**: lands for NEW machines only on 1.14 — existing nodes are unaffected. Before reprovisioning any node, evaluate hostPath-exec workloads (none known: localpv/rook/kata all run binaries from images). Do **not** preemptively set `mount.secure: false`.
- **NRI** is now enabled by default; no NRI plugins are configured, so it is inert.
- **`cluster.secret` / `cluster.id`** deprecations are handled by `talosctl gen config` at regeneration time (it emits `DiscoveryIdentityConfig`), not by these patches.
- **Resolver DoT/DoH** and native **`BGPInstanceConfig`** deliberately not adopted (BGP eval: cannot originate cluster prefixes).
- **`ghcr.io/siderolabs/installer`** is no longer published — already on the factory image, no action needed.
- **KubeNetworkConfig subnet validation** passes for `/17` + `/17` (verified with the v1.14 validator in the harness).

## Schema deltas / things that could not be expressed 1:1

1. **`machine.features.hostDNS` had to move to `ResolverConfig.hostDNS`** (contrary to the initial assumption that it is not deprecated): v1.14 deprecates it and the generated base already carries a `ResolverConfig` with hostDNS set, so keeping the v1alpha1 field is a hard validation conflict. Behavior is preserved exactly (`enabled`, `forwardKubeDNSToHost` from generated defaults + `resolveMemberNames: true` from our patch).
2. **`cluster.allowSchedulingOnControlPlanes: true` has no direct field** in KubeNodeConfig; it is expressed as *absence* of the control-plane `NoSchedule` taint, which requires delete + full re-specification of the generated KubeNodeConfig (map merges cannot delete keys). If a future talosctl changes the generated KubeNodeConfig labels, the replacement document in `12-k8s.yaml` must be kept in sync (currently carries the two generated labels).
3. **"No admission plugins" is expressed as deletion of the named `PodSecurity` document** — verified that with zero `KubeAdmissionControlConfig` documents the apiserver admission config list is empty (`internal/app/machined/pkg/controllers/k8s/control_plane.go`), matching `admissionControl: $patch: delete` semantics exactly.
4. **`DiscoveryServiceConfig.endpoint` is URL-normalized** to `http://10.10.0.100:9300/` (trailing slash) by `meta.URL` parsing; functionally identical.
5. **`cni: none` has no positive document form** — it is expressed as deletion of the generated `KubeFlannelCNIConfig`; verified that no flannel doc + no external CNI manifest = Talos deploys no CNI (`control_plane.go` flannel block is nil-gated).
